### PR TITLE
clear stack if last call was draw not when current call is draw

### DIFF
--- a/main.js
+++ b/main.js
@@ -125,13 +125,10 @@ var glpFcnBindings = {
             }
             this.glpMostRecentCalls.push(callDetails);
 
-            if (this.glpLastCallWasDraw) {
+            var lastFunction = this.glpCallsSinceDraw[this.glpCallsSinceDraw.length - 1];
+            if (lastFunction &&
+                (lastFunction[0] == "drawElements" || lastFunction[0] == "drawArrays")) {
               this.glpCallsSinceDraw = [];
-            }
-            if (name == "drawElements" || name == "drawArrays") {
-              this.glpLastCallWasDraw = true;
-            } else {
-              this.glpLastCallWasDraw = false;
             }
             this.glpCallsSinceDraw.push(callDetails);
         }


### PR DESCRIPTION
Previously CallStackSinceLastDraw was only displaying "DrawArray".  This was because we were clearing the stack when checking if the current call is a Draw call.

Fix:
Keep track of when the previous call was a draw and only clear the stack on that.
