### PR TITLE
Optimize glp call on WebGLRenderingContext

### DIFF
--- a/src/content_script/webgl_bind.js
+++ b/src/content_script/webgl_bind.js
@@ -39,12 +39,9 @@ function bindWebGL() {
         }
     }
 
-    WebGLRenderingContext.prototype.glp = function() {
-        if (this.__uuid == null) {
+    WebGLRenderingContext.prototype.__newGLP = function() {
+        if (this.__uuid === undefined) {
             this.__uuid = glpHelpers.guid();
-        }
-        if (this.__uuid in _glpModuleInstances) {
-            return _glpModuleInstances[this.__uuid];
         }
 
         var modules = {}
@@ -61,6 +58,10 @@ function bindWebGL() {
         modules.shaderViewer = new glpShaderViewer(this);
         _glpModuleInstances[this.__uuid] = modules;
         return modules;
+    }
+
+    WebGLRenderingContext.prototype.glp = function() {
+        return _glpModuleInstances[this.__uuid] ? _glpModuleInstances[this.__uuid] : this.__newGLP();
     }
 }
 


### PR DESCRIPTION
A non-trivial amount of execution time was being used here. With this change, this call no longer shows up when profiling CPU execution time.