### PR TITLE
getUniformLocation should return null if not successful

### DIFF
--- a/src/content_script/fcn_bindings.js
+++ b/src/content_script/fcn_bindings.js
@@ -114,14 +114,14 @@ var glpFcnBindings = {
       if (!(this.glp().pixelInspector.hasUniformLocation(program, n))) {
         var location = original.apply(this, args);
         if (!location) {
-          return;
+          return location;
         }
         return this.glp().pixelInspector.setUniformLocation(program, n, location);
       }
       if (!(this.glp().depthInspector.hasUniformLocation(program, n))) {
         var location = original.apply(this, args);
         if (!location) {
-          return;
+          return location;
         }
         return this.glp().depthInspector.setUniformLocation(program, n, location);
       }


### PR DESCRIPTION
Conform to the webGL spec as pointed out here: https://github.com/3Dparallax/insight/issues/112.